### PR TITLE
Add admin member and course pages

### DIFF
--- a/app/admin/courses/page.tsx
+++ b/app/admin/courses/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminCoursesPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">강의 등록</h1>
+      <p className="text-gray-400">강의 등록 페이지 준비 중입니다.</p>
+    </div>
+  )
+}

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -1,0 +1,8 @@
+export default function MembersPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">회원 관리</h1>
+      <p className="text-gray-400">회원 관리 페이지 준비 중입니다.</p>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,9 +1,23 @@
+import Link from 'next/link'
+
 export default function AdminPage() {
   return (
     <div className="min-h-screen bg-black text-white p-6">
-      <h1 className="text-3xl font-bold text-red-500 mb-4">관리자 대시보드</h1>
-      <p className="text-gray-300">여기에서 회원 목록 관리 및 강의 등록 등을 수행합니다.</p>
-      {/* TODO: 관리자 기능 구현 */}
+      <h1 className="text-3xl font-bold text-red-500 mb-8">관리자 대시보드</h1>
+      <ul className="space-y-4">
+        <li className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+          <Link href="/admin/members" className="block">
+            <h2 className="text-xl font-semibold mb-2">회원 관리</h2>
+            <p className="text-gray-400">회원 목록 조회 및 권한 설정 기능 (예정)</p>
+          </Link>
+        </li>
+        <li className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+          <Link href="/admin/courses" className="block">
+            <h2 className="text-xl font-semibold mb-2">강의 등록</h2>
+            <p className="text-gray-400">새로운 강의 등록 및 편집 기능 (예정)</p>
+          </Link>
+        </li>
+      </ul>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- link to new admin sections in `/admin`
- scaffold `/admin/members` for 회원 관리
- scaffold `/admin/courses` for 강의 등록

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd3e4abdc8323924c121ef4c6600b