### PR TITLE
Add admin edit forms and payout pages

### DIFF
--- a/app/admin/courses/[slug]/page.tsx
+++ b/app/admin/courses/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from 'next/navigation'
+import { demoCourses } from '@/lib/demo-courses'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+interface Props { params: { slug: string } }
+
+export default function EditCoursePage({ params }: Props) {
+  const course = demoCourses.find((c) => c.slug === params.slug)
+  if (!course) return notFound()
+
+  return (
+    <div className="min-h-screen bg-black text-white p-6 space-y-4">
+      <h1 className="text-3xl font-bold text-red-500">강의 수정</h1>
+      <div className="space-y-2">
+        <label className="block">
+          <span className="block mb-1">제목</span>
+          <Input defaultValue={course.title} />
+        </label>
+        <label className="block">
+          <span className="block mb-1">강사</span>
+          <Input defaultValue={course.instructor} />
+        </label>
+        <label className="block">
+          <span className="block mb-1">가격</span>
+          <Input defaultValue={course.salePrice} />
+        </label>
+        <Button className="bg-red-600 hover:bg-red-700">저장</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/courses/new/page.tsx
+++ b/app/admin/courses/new/page.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export default function NewCoursePage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6 space-y-4">
+      <h1 className="text-3xl font-bold text-red-500">강의 추가</h1>
+      <div className="space-y-2">
+        <label className="block">
+          <span className="block mb-1">제목</span>
+          <Input />
+        </label>
+        <label className="block">
+          <span className="block mb-1">강사</span>
+          <Input />
+        </label>
+        <label className="block">
+          <span className="block mb-1">가격</span>
+          <Input />
+        </label>
+        <Button className="bg-red-600 hover:bg-red-700">추가</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/courses/page.tsx
+++ b/app/admin/courses/page.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { demoCourses } from '@/lib/demo-courses'
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+
+export default function AdminCoursesPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-6">강의 등록</h1>
+      <div className="mb-4">
+        <Link href="/admin/courses/new">
+          <Button className="bg-red-600 hover:bg-red-700">강의 추가</Button>
+        </Link>
+      </div>
+      <Table className="bg-gray-900 border border-gray-700 rounded-md">
+        <TableHeader>
+          <TableRow className="bg-gray-800">
+            <TableHead>제목</TableHead>
+            <TableHead>강사</TableHead>
+            <TableHead>가격</TableHead>
+            <TableHead className="text-right">작업</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {demoCourses.map((c) => (
+            <TableRow key={c.slug} className="border-t border-gray-700">
+              <TableCell>{c.title}</TableCell>
+              <TableCell>{c.instructor}</TableCell>
+              <TableCell>{c.salePrice}</TableCell>
+              <TableCell className="text-right space-x-2">
+                <Link href={`/admin/courses/${c.slug}`} className="inline-block">
+                  <Button size="sm" variant="secondary">수정</Button>
+                </Link>
+                <Button size="sm" variant="destructive">삭제</Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/admin/members/[id]/page.tsx
+++ b/app/admin/members/[id]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from 'next/navigation'
+import { demoMembers } from '@/lib/demo-members'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+interface Props { params: { id: string } }
+
+export default function EditMemberPage({ params }: Props) {
+  const member = demoMembers.find((m) => m.id === Number(params.id))
+  if (!member) return notFound()
+
+  return (
+    <div className="min-h-screen bg-black text-white p-6 space-y-4">
+      <h1 className="text-3xl font-bold text-red-500">회원 수정</h1>
+      <div className="space-y-2">
+        <label className="block">
+          <span className="block mb-1">이름</span>
+          <Input defaultValue={member.name} />
+        </label>
+        <label className="block">
+          <span className="block mb-1">이메일</span>
+          <Input defaultValue={member.email} />
+        </label>
+        <label className="block">
+          <span className="block mb-1">권한</span>
+          <Input defaultValue={member.role} />
+        </label>
+        <Button className="bg-red-600 hover:bg-red-700">저장</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/members/new/page.tsx
+++ b/app/admin/members/new/page.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export default function NewMemberPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6 space-y-4">
+      <h1 className="text-3xl font-bold text-red-500">회원 추가</h1>
+      <div className="space-y-2">
+        <label className="block">
+          <span className="block mb-1">이름</span>
+          <Input />
+        </label>
+        <label className="block">
+          <span className="block mb-1">이메일</span>
+          <Input />
+        </label>
+        <label className="block">
+          <span className="block mb-1">권한</span>
+          <Input />
+        </label>
+        <Button className="bg-red-600 hover:bg-red-700">추가</Button>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/members/page.tsx
+++ b/app/admin/members/page.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { demoMembers } from '@/lib/demo-members'
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+
+export default function MembersPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-6">회원 관리</h1>
+      <div className="mb-4">
+        <Link href="/admin/members/new">
+          <Button className="bg-red-600 hover:bg-red-700">회원 추가</Button>
+        </Link>
+      </div>
+      <Table className="bg-gray-900 border border-gray-700 rounded-md">
+        <TableHeader>
+          <TableRow className="bg-gray-800">
+            <TableHead>이름</TableHead>
+            <TableHead>이메일</TableHead>
+            <TableHead>권한</TableHead>
+            <TableHead className="text-right">작업</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {demoMembers.map((m) => (
+            <TableRow key={m.id} className="border-t border-gray-700">
+              <TableCell>{m.name}</TableCell>
+              <TableCell>{m.email}</TableCell>
+              <TableCell>{m.role}</TableCell>
+              <TableCell className="text-right space-x-2">
+                <Link href={`/admin/members/${m.id}`} className="inline-block">
+                  <Button size="sm" variant="secondary">수정</Button>
+                </Link>
+                <Button size="sm" variant="destructive">삭제</Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,9 +1,29 @@
+import Link from 'next/link'
+
 export default function AdminPage() {
   return (
     <div className="min-h-screen bg-black text-white p-6">
-      <h1 className="text-3xl font-bold text-red-500 mb-4">관리자 대시보드</h1>
-      <p className="text-gray-300">여기에서 회원 목록 관리 및 강의 등록 등을 수행합니다.</p>
-      {/* TODO: 관리자 기능 구현 */}
+      <h1 className="text-3xl font-bold text-red-500 mb-8">관리자 대시보드</h1>
+      <ul className="space-y-4">
+        <li className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+          <Link href="/admin/members" className="block">
+            <h2 className="text-xl font-semibold mb-2">회원 관리</h2>
+            <p className="text-gray-400">회원 목록 조회 및 권한 설정 기능 (예정)</p>
+          </Link>
+        </li>
+        <li className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+          <Link href="/admin/courses" className="block">
+            <h2 className="text-xl font-semibold mb-2">강의 등록</h2>
+            <p className="text-gray-400">새로운 강의 등록 및 편집 기능 (예정)</p>
+          </Link>
+        </li>
+        <li className="bg-gray-900 border border-gray-700 rounded-lg p-4">
+          <Link href="/admin/payouts" className="block">
+            <h2 className="text-xl font-semibold mb-2">정산 관리</h2>
+            <p className="text-gray-400">출금 요청 내역 확인</p>
+          </Link>
+        </li>
+      </ul>
     </div>
   )
 }

--- a/app/admin/payouts/page.tsx
+++ b/app/admin/payouts/page.tsx
@@ -1,0 +1,28 @@
+import { demoPayouts } from '@/lib/demo-payouts'
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table'
+
+export default function PayoutsPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-6">정산 관리</h1>
+      <Table className="bg-gray-900 border border-gray-700 rounded-md">
+        <TableHeader>
+          <TableRow className="bg-gray-800">
+            <TableHead>선수</TableHead>
+            <TableHead>금액</TableHead>
+            <TableHead>상태</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {demoPayouts.map((p) => (
+            <TableRow key={p.id} className="border-t border-gray-700">
+              <TableCell>{p.athlete}</TableCell>
+              <TableCell>{p.amount}</TableCell>
+              <TableCell>{p.status}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/athlete-profile/page.tsx
+++ b/app/athlete-profile/page.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'
 import { Input } from '@/components/ui/input'
+import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -121,6 +122,11 @@ export default function AthleteProfilePage() {
               )}
             />
             <Button type="submit" className="w-full bg-red-600 hover:bg-red-700">저장하기</Button>
+            <div className="text-center mt-4">
+              <Link href="/payout-request" className="text-red-400 underline">
+                정산 신청하기
+              </Link>
+            </div>
           </form>
         </Form>
       </div>

--- a/app/payout-request/page.tsx
+++ b/app/payout-request/page.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export default function PayoutRequestPage() {
+  return (
+    <div className="min-h-screen bg-black text-white flex items-center justify-center p-6">
+      <div className="w-full max-w-sm space-y-4">
+        <h1 className="text-3xl font-bold text-center text-red-500">정산 신청</h1>
+        <label className="block">
+          <span className="block mb-1">출금 금액</span>
+          <Input placeholder="₩" />
+        </label>
+        <Button className="w-full bg-red-600 hover:bg-red-700">신청하기</Button>
+      </div>
+    </div>
+  )
+}

--- a/lib/demo-members.ts
+++ b/lib/demo-members.ts
@@ -1,0 +1,12 @@
+export interface MemberData {
+  id: number
+  name: string
+  email: string
+  role: string
+}
+
+export const demoMembers: MemberData[] = [
+  { id: 1, name: '김철수', email: 'chulsoo@example.com', role: '관리자' },
+  { id: 2, name: '이영희', email: 'younghee@example.com', role: '수련생' },
+  { id: 3, name: '박민수', email: 'minsoo@example.com', role: '수련생' },
+]

--- a/lib/demo-payouts.ts
+++ b/lib/demo-payouts.ts
@@ -1,0 +1,11 @@
+export interface PayoutRequest {
+  id: number
+  athlete: string
+  amount: string
+  status: '대기' | '완료'
+}
+
+export const demoPayouts: PayoutRequest[] = [
+  { id: 1, athlete: '김철수', amount: '₩300,000', status: '대기' },
+  { id: 2, athlete: '이영희', amount: '₩150,000', status: '완료' },
+]


### PR DESCRIPTION
## Summary
- link to add/edit pages for members and courses
- create forms for adding and editing courses and members
- add athlete payout request page and admin payout dashboard
- include demo payout data

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd3e4abdc8323924c121ef4c6600b