### PR TITLE
Add placeholder pages for navigation links

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">회사 소개</h1>
+      <p>Fighting Korea 플랫폼에 대해 소개하는 페이지입니다.</p>
+    </div>
+  )
+}

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,0 +1,8 @@
+export default function CategoriesPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">카테고리</h1>
+      <p>카테고리별 강의 목록을 보여줄 예정입니다.</p>
+    </div>
+  )
+}

--- a/app/company/about/page.tsx
+++ b/app/company/about/page.tsx
@@ -1,0 +1,8 @@
+export default function CompanyAboutPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">회사소개</h1>
+      <p>회사에 대한 소개 페이지입니다.</p>
+    </div>
+  )
+}

--- a/app/company/instructor-support/page.tsx
+++ b/app/company/instructor-support/page.tsx
@@ -1,0 +1,8 @@
+export default function InstructorSupportPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">강사 지원</h1>
+      <p>강사 지원 안내 페이지입니다.</p>
+    </div>
+  )
+}

--- a/app/company/jobs/page.tsx
+++ b/app/company/jobs/page.tsx
@@ -1,0 +1,8 @@
+export default function JobsPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">채용정보</h1>
+      <p>현재 채용 중인 포지션을 안내하는 페이지입니다.</p>
+    </div>
+  )
+}

--- a/app/company/partnership/page.tsx
+++ b/app/company/partnership/page.tsx
@@ -1,0 +1,8 @@
+export default function PartnershipPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">제휴문의</h1>
+      <p>제휴 및 협업 문의 안내 페이지입니다.</p>
+    </div>
+  )
+}

--- a/app/instructors/page.tsx
+++ b/app/instructors/page.tsx
@@ -1,0 +1,8 @@
+export default function InstructorsPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">강사진</h1>
+      <p>강사진 목록 페이지입니다. 추후 실제 데이터로 대체될 예정입니다.</p>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -312,27 +312,27 @@ export default function HomePage() {
               <h4 className="font-semibold mb-4">강의</h4>
               <ul className="space-y-2 text-gray-400">
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/courses" className="hover:text-red-400">
                     노기 주짓수
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/courses" className="hover:text-red-400">
                     도복 주짓수
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/courses" className="hover:text-red-400">
                     레슬링
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/courses" className="hover:text-red-400">
                     MMA
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/courses" className="hover:text-red-400">
                     복싱
                   </Link>
                 </li>
@@ -343,27 +343,27 @@ export default function HomePage() {
               <h4 className="font-semibold mb-4">지원</h4>
               <ul className="space-y-2 text-gray-400">
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/support/customer-service" className="hover:text-red-400">
                     고객센터
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/support/faq" className="hover:text-red-400">
                     FAQ
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/support/refund-policy" className="hover:text-red-400">
                     환불정책
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/support/terms" className="hover:text-red-400">
                     이용약관
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/support/privacy" className="hover:text-red-400">
                     개인정보처리방침
                   </Link>
                 </li>
@@ -374,22 +374,22 @@ export default function HomePage() {
               <h4 className="font-semibold mb-4">회사</h4>
               <ul className="space-y-2 text-gray-400">
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/company/about" className="hover:text-red-400">
                     회사소개
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/company/instructor-support" className="hover:text-red-400">
                     강사 지원
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/company/partnership" className="hover:text-red-400">
                     제휴문의
                   </Link>
                 </li>
                 <li>
-                  <Link href="#" className="hover:text-red-400">
+                  <Link href="/company/jobs" className="hover:text-red-400">
                     채용정보
                   </Link>
                 </li>

--- a/app/support/customer-service/page.tsx
+++ b/app/support/customer-service/page.tsx
@@ -1,0 +1,8 @@
+export default function CustomerServicePage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">고객센터</h1>
+      <p>문의 사항이 있으시면 support@example.com 으로 연락 주세요.</p>
+    </div>
+  )
+}

--- a/app/support/faq/page.tsx
+++ b/app/support/faq/page.tsx
@@ -1,0 +1,8 @@
+export default function FAQPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">FAQ</h1>
+      <p>자주 묻는 질문을 정리한 페이지입니다.</p>
+    </div>
+  )
+}

--- a/app/support/privacy/page.tsx
+++ b/app/support/privacy/page.tsx
@@ -1,0 +1,8 @@
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">개인정보처리방침</h1>
+      <p>개인정보 보호 정책을 안내하는 페이지입니다.</p>
+    </div>
+  )
+}

--- a/app/support/refund-policy/page.tsx
+++ b/app/support/refund-policy/page.tsx
@@ -1,0 +1,8 @@
+export default function RefundPolicyPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">환불정책</h1>
+      <p>환불 규정에 대한 안내 페이지입니다.</p>
+    </div>
+  )
+}

--- a/app/support/terms/page.tsx
+++ b/app/support/terms/page.tsx
@@ -1,0 +1,8 @@
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold text-red-500 mb-4">이용약관</h1>
+      <p>서비스 이용약관을 안내하는 페이지입니다.</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create static pages for instructors, categories and about
- add support and company info pages
- update footer links to navigate to new routes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515cf500f08323a5dd93dee93880d2